### PR TITLE
US 139518 As a dev I can switch between prod and test app stores more easily

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
@@ -159,7 +159,7 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
             new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
                 AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(
                 ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences())),
-                Collections.singletonList(SMARTStore.STORE_NAME)),
+                Collections.singletonList(SMARTStore.getStoreName(getContext()))),
         otherVersionsSuccessRequestListener, err -> err.printStackTrace());
 
     getRecyclerView().addOnScrollListener(endlessRecyclerOnScrollListener);

--- a/app/src/main/java/cm/aptoide/pt/smart/appfiltering/AddedAppsFetcher.kt
+++ b/app/src/main/java/cm/aptoide/pt/smart/appfiltering/AddedAppsFetcher.kt
@@ -62,7 +62,7 @@ class AddedAppsFetcher(httpClient: OkHttpClient, private val context: Context) {
         Observable.fromCallable { emptyAppsList }
     } else {
         Observable.from(stores)
-                .filter { store -> store.storeName == SMARTStore.STORE_NAME }
+                .filter { store -> store.storeName == SMARTStore.getStoreName(context) }
                 .map { store ->
                     Observable.from(store.platforms)
                             .filter { platform -> Build.MODEL == platform.platform }

--- a/app/src/main/java/cm/aptoide/pt/smart/appfiltering/FilteredAppsFetcher.kt
+++ b/app/src/main/java/cm/aptoide/pt/smart/appfiltering/FilteredAppsFetcher.kt
@@ -64,7 +64,7 @@ class FilteredAppsFetcher(httpClient: OkHttpClient, private val context: Context
         Observable.fromCallable { emptyAppsLists }
     } else {
         Observable.from(stores)
-                .filter { store -> store.storeName == SMARTStore.STORE_NAME }
+                .filter { store -> store.storeName == SMARTStore.getStoreName(context) }
                 .map { store ->
                     Observable.from(store.platforms)
                             .filter { platform -> Build.MODEL == platform.platform }

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoresFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoresFragment.java
@@ -102,7 +102,7 @@ public class MyStoresFragment extends StoreTabWidgetsGridRecyclerFragment implem
 //    attachPresenter(myStoresPresenter);
 
     getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
-            .newStoreFragment(SMARTStore.STORE_NAME, SMARTStore.STORE_COLOR), true);
+            .newStoreFragment(SMARTStore.getStoreName(view.getContext()), SMARTStore.STORE_COLOR), true);
   }
 
   @Override protected Observable<List<Displayable>> buildDisplayables(boolean refresh, String url,

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
@@ -1,14 +1,33 @@
 package cm.aptoide.pt.store.view.my;
 
+import android.content.Context;
 import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
 
 public class SMARTStore {
-    private static final boolean DEBUG = "userdebug".equals(Build.TYPE);
+    private static final String TAG = SMARTStore.class.getSimpleName();
 
-    public static final String STORE_NAME = DEBUG ? "aptoide-test-store" : "smarttech-iq";
-    //public static final String STORE_NAME = "smarttech-iq";
-    //public static final String STORE_NAME = "aptoide-test-store";
+    public static final String FIELD_ID_IA_APP_STORE_ENV = "smart_app_store_env";
+
+    private static final boolean DEBUG = "userdebug".equals(Build.TYPE);
+    private static final String STORE_RELEASE_NAME = "smarttech-iq";
+    private static final String STORE_DEBUG_NAME = "aptoide-test-store";
+    private static final String DEFAULT_STORE_NAME = DEBUG ? STORE_DEBUG_NAME : STORE_RELEASE_NAME;
+
     public static final String STORE_COLOR = "red";
 
     private SMARTStore() {}
+
+    public static String getStoreName(Context context) {
+        if (context == null) {
+            Log.e(TAG, "Cannot get context for " + FIELD_ID_IA_APP_STORE_ENV + ", returning default environment!");
+            return DEFAULT_STORE_NAME;
+        }
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            String name = Settings.Global.getString(context.getContentResolver(), FIELD_ID_IA_APP_STORE_ENV);
+            return name == null ? DEFAULT_STORE_NAME : name;
+        }
+        return DEFAULT_STORE_NAME;
+    }
 }

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
@@ -32,8 +32,7 @@ public class SMARTStore {
             return Settings.Global.getInt(contentResolver, USE_RELEASE_APP_STORE_KEY) == 1;
         } catch (Settings.SettingNotFoundException e) {
             Log.e(TAG, "Error while getting app store env setting", e);
-            Settings.Global.putInt(contentResolver, USE_RELEASE_APP_STORE_KEY, IS_DEBUG_BUILD ? 0 : 1);
+            return !IS_DEBUG_BUILD;
         }
-        return !IS_DEBUG_BUILD;
     }
 }

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
@@ -3,12 +3,9 @@ package cm.aptoide.pt.store.view.my;
 import android.content.Context;
 import android.os.Build;
 import android.provider.Settings;
-import android.util.Log;
 
 public class SMARTStore {
-    private static final String TAG = SMARTStore.class.getSimpleName();
-
-    public static final String FIELD_ID_IA_APP_STORE_ENV = "smart_app_store_env";
+    public static final String USE_RELEASE_APP_STORE_KEY = "Use Release App Store";
 
     private static final boolean DEBUG = "userdebug".equals(Build.TYPE);
     private static final String STORE_RELEASE_NAME = "smarttech-iq";
@@ -21,13 +18,19 @@ public class SMARTStore {
 
     public static String getStoreName(Context context) {
         if (context == null) {
-            Log.e(TAG, "Cannot get context for " + FIELD_ID_IA_APP_STORE_ENV + ", returning default environment!");
             return DEFAULT_STORE_NAME;
         }
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            String name = Settings.Global.getString(context.getContentResolver(), FIELD_ID_IA_APP_STORE_ENV);
-            return name == null ? DEFAULT_STORE_NAME : name;
+        return isReleaseAppStore(context) ? STORE_RELEASE_NAME : STORE_DEBUG_NAME;
+    }
+
+    private static boolean isReleaseAppStore(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            try {
+                return Settings.Global.getInt(context.getContentResolver(), USE_RELEASE_APP_STORE_KEY) != 0;
+            } catch (Settings.SettingNotFoundException e) {
+                Settings.Global.putInt(context.getContentResolver(), USE_RELEASE_APP_STORE_KEY, !DEBUG ? 1 : 0);
+            }
         }
-        return DEFAULT_STORE_NAME;
+        return !DEBUG;
     }
 }

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/SMARTStore.java
@@ -1,18 +1,21 @@
 package cm.aptoide.pt.store.view.my;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.os.Build;
 import android.provider.Settings;
+import android.util.Log;
 
 public class SMARTStore {
+    public static final String TAG = SMARTStore.class.getSimpleName();
+
     public static final String USE_RELEASE_APP_STORE_KEY = "Use Release App Store";
-
-    private static final boolean DEBUG = "userdebug".equals(Build.TYPE);
-    private static final String STORE_RELEASE_NAME = "smarttech-iq";
-    private static final String STORE_DEBUG_NAME = "aptoide-test-store";
-    private static final String DEFAULT_STORE_NAME = DEBUG ? STORE_DEBUG_NAME : STORE_RELEASE_NAME;
-
     public static final String STORE_COLOR = "red";
+
+    private static final String RELEASE_STORE_NAME = "smarttech-iq";
+    private static final String DEBUG_STORE_NAME = "aptoide-test-store";
+    private static final boolean IS_DEBUG_BUILD = "userdebug".equals(Build.TYPE);
+    private static final String DEFAULT_STORE_NAME = IS_DEBUG_BUILD ? DEBUG_STORE_NAME : RELEASE_STORE_NAME;
 
     private SMARTStore() {}
 
@@ -20,17 +23,17 @@ public class SMARTStore {
         if (context == null) {
             return DEFAULT_STORE_NAME;
         }
-        return isReleaseAppStore(context) ? STORE_RELEASE_NAME : STORE_DEBUG_NAME;
+        return isReleaseAppStore(context) ? RELEASE_STORE_NAME : DEBUG_STORE_NAME;
     }
 
     private static boolean isReleaseAppStore(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            try {
-                return Settings.Global.getInt(context.getContentResolver(), USE_RELEASE_APP_STORE_KEY) != 0;
-            } catch (Settings.SettingNotFoundException e) {
-                Settings.Global.putInt(context.getContentResolver(), USE_RELEASE_APP_STORE_KEY, !DEBUG ? 1 : 0);
-            }
+        ContentResolver contentResolver = context.getContentResolver();
+        try {
+            return Settings.Global.getInt(contentResolver, USE_RELEASE_APP_STORE_KEY) == 1;
+        } catch (Settings.SettingNotFoundException e) {
+            Log.e(TAG, "Error while getting app store env setting", e);
+            Settings.Global.putInt(contentResolver, USE_RELEASE_APP_STORE_KEY, IS_DEBUG_BUILD ? 0 : 1);
         }
-        return !DEBUG;
+        return !IS_DEBUG_BUILD;
     }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
@@ -163,18 +163,16 @@ public class MainActivity extends BottomNavigationActivity
   }
 
   private void registerStoreEnvironmentSettingObserver() {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      unregisterStoreEnvironmentSettingObserver();
-      storeEnvSettingObserver = new ContentObserver(new Handler()) {
-        @Override
-        public void onChange(boolean selfChange) {
-          shouldRestart = true;
-        }
-      };
+    unregisterStoreEnvironmentSettingObserver();
+    storeEnvSettingObserver = new ContentObserver(new Handler()) {
+      @Override
+      public void onChange(boolean selfChange) {
+        shouldRestart = true;
+      }
+    };
 
-      Uri uri = Settings.Global.getUriFor(SMARTStore.USE_RELEASE_APP_STORE_KEY);
-      getActivity().getContentResolver().registerContentObserver(uri, false, storeEnvSettingObserver);
-    }
+    Uri uri = Settings.Global.getUriFor(SMARTStore.USE_RELEASE_APP_STORE_KEY);
+    getActivity().getContentResolver().registerContentObserver(uri, false, storeEnvSettingObserver);
   }
 
   private void unregisterStoreEnvironmentSettingObserver() {


### PR DESCRIPTION
**What does this PR do?**

Add an observer to choose appropriate App Store environment (debug/release) according to selected in Settings.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SMARTStore.java
- [ ] MainActivity.java

**How should this be manually tested?**

 Flow on how to test this or QA Tickets related to this use-case: https://smartvcs.visualstudio.com/iQ%20Home/_workitems/edit/139518

Go to Settings -> Advanced -> Select "App Store Environment" option -> choose relevant environment
Then go to Apps and open App Store

**What are the relevant tickets?**

 Tickets related to this pull-request:
https://smartvcs.visualstudio.com/iQ%20Home/_workitems/edit/139518

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass